### PR TITLE
Use strings for python/poetry version numbers in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Publish Package to PyPI
         uses: celsiusnarhwal/poetry-publish@v2
         with:
-          python-version: 3.10
-          poetry-version: 1.4.2
+          python-version: "3.10"
+          poetry-version: "1.4.2"
           token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
YAML tries to be too smart, so let's force things to be strings for version numbers.