### PR TITLE
Merge namespaced key/values into non-namespaced key/values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,11 +27,16 @@ Note that for the basic functioning of this loader, the `environments <https://w
 Configuration Variables
 -----------------------
 
+Both of the following configuration values can be set in the environment _or_ in the ``settings.toml`` (or equivalent format) in question.
+
 - ``AWS_SSM_PARAMETER_PROJECT_PREFIX``: Required.
-  The ``project`` prefix in the parameter store path. This value is required. It may be set in ``settings.toml`` (or equivalent), *or* may be sourced from the environment directly. This latter is a useful option if you wish to avoid using materialized settings files and instead wish to use environment variables only.
+  The ``project`` prefix in the parameter store path.
 
 - ``AWS_SSM_PARAMETER_NAMESPACE``: Optional.
   This provides an additional level of grouping once the project and environment have been determined.
+
+.. note::
+   If a namespace is utilized, be aware that namespaced settings will be merged with non-namespaced settings. This merge is a naive one, where namespaced settings will completely overwrite non-namespaced settings with the same key.
 
 Parameter Store Details
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -27,16 +27,22 @@ Note that for the basic functioning of this loader, the `environments <https://w
 Configuration Variables
 -----------------------
 
-Both of the following configuration values can be set in the environment _or_ in the ``settings.toml`` (or equivalent format) in question.
+Both of the following configuration values should be set in the *environment* to avoid a chicken/egg scenario for initializing this custom loader:
 
-- ``AWS_SSM_PARAMETER_PROJECT_PREFIX``: Required.
-  The ``project`` prefix in the parameter store path.
+- ``SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF``: Required.
+  The ``project`` prefix in the parameter store path. For example, if the parameter hierarchy looks something like ``/baldur/development/database_uri``, then in this case ``SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF=baldur``.
 
-- ``AWS_SSM_PARAMETER_NAMESPACE``: Optional.
-  This provides an additional level of grouping once the project and environment have been determined.
+- ``SSM_PARAMETER_NAMESPACE_FOR_DYNACONF``: Optional.
+  This provides an additional level of grouping once the project and environment have been determined. For example, if the parameter hierarchy looks something like ``/baldur/pr-123/development/database_uri``, then ``SSM_PARAMETER_NAMESPACE_FOR_DYNACONF=pr-123``.
 
 .. note::
-   If a namespace is utilized, be aware that namespaced settings will be merged with non-namespaced settings. This merge is a naive one, where namespaced settings will completely overwrite non-namespaced settings with the same key.
+   If a namespace is utilized, be aware that namespaced settings will be *merged* with non-namespaced settings. This merge is a naive one, where namespaced settings will completely overwrite non-namespaced settings with the same key.
+
+The following optional variables should be set in your ``settings.toml`` (or equivalent format), if desired:
+
+- ``SSM_ENDPOINT_URL_FOR_DYNACONF``: If your AWS SSM uses a different endpoint than the AWS default. This can be useful for local development when you are running something like `LocalStack <https://localstack.cloud/>`_.
+- ``SSM_SESSION_FOR_DYNACONF``: If you require custom `boto3.session.Session <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`_ arguments, you can specify then as a dictionary here. Note that this will override the default ``boto3`` credential configuration.
+
 
 Parameter Store Details
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/dynaconf_aws_loader/loader.py
+++ b/dynaconf_aws_loader/loader.py
@@ -139,6 +139,10 @@ def load(
                 silent=silent,
             )
             if normal_results:
+                filter_strategy = obj.get("NAMESPACE_FILTER_STRATEGY")
+                if filter_strategy:
+                    normal_results = filter_strategy(normal_results)
+
                 obj.update(
                     normal_results,
                     loader_identifier=IDENTIFIER,

--- a/dynaconf_aws_loader/loader.py
+++ b/dynaconf_aws_loader/loader.py
@@ -26,8 +26,8 @@ logger = logging.getLogger("dynaconf")
 def get_client(obj) -> SSMClient:
     """Get a boto3 client to access AWS System Parameter Store"""
 
-    endpoint_url = obj.get("AWS_ENDPOINT_URL_FOR_DYNACONF")
-    session = boto3.session.Session(**obj.get("AWS_SESSION_FOR_DYNACONF", {}))
+    endpoint_url = obj.get("SSM_ENDPOINT_URL_FOR_DYNACONF")
+    session = boto3.session.Session(**obj.get("SSM_SESSION_FOR_DYNACONF", {}))
     client = session.client(service_name="ssm", endpoint_url=endpoint_url)
     return client
 
@@ -82,8 +82,8 @@ def load(
 
     """
 
-    prefix_key_name = "AWS_SSM_PARAMETER_PROJECT_PREFIX"
-    namespace_key_name = "AWS_SSM_PARAMETER_NAMESPACE"
+    prefix_key_name = "SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"
+    namespace_key_name = "SSM_PARAMETER_NAMESPACE_FOR_DYNACONF"
 
     try:
         client = get_client(obj)
@@ -139,7 +139,7 @@ def load(
                 silent=silent,
             )
             if normal_results:
-                filter_strategy = obj.get("NAMESPACE_FILTER_STRATEGY")
+                filter_strategy = obj.get("AWS_SSM_NAMESPACE_FILTER_STRATEGY")
                 if filter_strategy:
                     normal_results = filter_strategy(normal_results)
 

--- a/dynaconf_aws_loader/loader.py
+++ b/dynaconf_aws_loader/loader.py
@@ -14,7 +14,7 @@ from dynaconf.utils import build_env_list
 from dynaconf.utils.parse_conf import parse_conf_data
 
 from . import IDENTIFIER
-from .util import slashes_to_dict
+from .util import slashes_to_dict, pull_from_env_or_obj
 
 if t.TYPE_CHECKING:
     from mypy_boto3_ssm.client import SSMClient
@@ -82,6 +82,9 @@ def load(
 
     """
 
+    prefix_key_name = "AWS_SSM_PARAMETER_PROJECT_PREFIX"
+    namespace_key_name = "AWS_SSM_PARAMETER_NAMESPACE"
+
     try:
         client = get_client(obj)
     except NoRegionError:
@@ -96,17 +99,14 @@ def load(
 
     env_list = build_env_list(obj, env or obj.current_env)
 
-    project_prefix: str = obj.get(
-        "AWS_SSM_PARAMETER_PROJECT_PREFIX",
-        os.environ.get("AWS_SSM_PARAMETER_PROJECT_PREFIX"),
-    )
+    project_prefix = pull_from_env_or_obj(prefix_key_name, os.environ, obj)
+    namespace_prefix = pull_from_env_or_obj(namespace_key_name, os.environ, obj)
 
     if project_prefix is None:
         raise ValueError(
-            "AWS_SSM_PARAMETER_PROJECT_PREFIX must be set in settings"
+            f"{prefix_key_name} must be set in settings"
             " or environment for AWS SSM loader to work."
         )
-    namespace_prefix: str | None = obj.get("AWS_SSM_PARAMETER_NAMESPACE", None)
 
     for env_name in env_list:
         env_name = env_name.lower()
@@ -116,62 +116,124 @@ def load(
             path = f"{path}/{namespace_prefix}"
 
         if key is not None:
-            logger.debug(
-                "Attempting to load parameter %s from AWS SSM for env %s."
-                % (key, env_name)
+            value = _fetch_single_parameter(
+                client,
+                project_prefix=project_prefix,
+                env_name=env_name,
+                namespace_prefix=namespace_prefix,
+                silent=silent,
             )
-
-            try:
-                value = client.get_parameter(Name=f"/{path}/{key}", WithDecryption=True)
-            except (ClientError, BotoCoreError):
-                if silent:
-                    logger.exception("Could not connect to AWS SSM.")
-                    return
-                raise
-
-            if data := value.get("Parameter"):
-                parsed_value = parse_conf_data(
-                    data["Value"], tomlfy=True, box_settings=obj
-                )
-                if parsed_value:
-                    obj.set(key, parsed_value, validate=validate)
+            if value:
+                obj.set(key, value, validate=validate)
 
             return
-
-        # With no ``key`` specified, we load all data from the source
-        # that we are allowed to access.
-        logger.debug(
-            "Attempting to load all parameters from AWS SSM for path %s." % path
-        )
-        data = []
-        paginator = client.get_paginator("get_parameters_by_path")
-
-        try:
-            for page in paginator.paginate(
-                Path=path, Recursive=True, WithDecryption=True
-            ):
-                for parameter in page["Parameters"]:
-                    data.append({parameter["Name"]: parameter["Value"]})
-
-            result = parse_conf_data(data=slashes_to_dict(data), tomlfy=True)
-
-            if result and project_prefix in result:
-                # Prune out the prefixes before setting on the object
-                result = result[project_prefix]
-
-                if result and env_name in result:
-                    result = result[env_name]
-
-                if namespace_prefix is not None and namespace_prefix in result:
-                    result = result[namespace_prefix]
-
+        else:
+            # Fetch non-namespaced and namespaced keys, merging the latter into
+            # the former.
+            # TODO use single path query for both
+            normal_results = _fetch_all_parameters(
+                client=client,
+                project_prefix=project_prefix,
+                env_name=env_name,
+                namespace_prefix=None,
+                silent=silent,
+            )
+            if normal_results:
                 obj.update(
-                    result,
+                    normal_results,
                     loader_identifier=IDENTIFIER,
                     validate=validate,
                 )
-        except (ClientError, BotoCoreError):
-            if silent:
-                logger.exception("Could not connect to AWS SSM.")
-                return
-            raise
+
+            if namespace_prefix is not None:
+                namespaced_results = _fetch_all_parameters(
+                    client=client,
+                    project_prefix=project_prefix,
+                    env_name=env_name,
+                    namespace_prefix=namespace_prefix,
+                    silent=silent,
+                )
+
+                if namespaced_results:
+                    obj.update(
+                        namespaced_results,
+                        loader_identifier=IDENTIFIER,
+                        validate=validate,
+                    )
+
+
+def _fetch_single_parameter(
+    client,
+    project_prefix: str,
+    env_name: str,
+    namespace_prefix: str | None,
+    silent: bool = True,
+):
+    """
+    Fetch single parameter by path.
+    """
+
+    path = f"/{project_prefix}/{env_name}"
+    if namespace_prefix is not None:
+        path = f"{path}/{namespace_prefix}"
+
+    logger.debug("Attempting to load a single parameter %s from AWS SSM" % path)
+
+    try:
+        value = client.get_parameter(Name=path, WithDecryption=True)
+    except (ClientError, BotoCoreError):
+        logger.exception("Could not connect to AWS SSM.")
+        if silent:
+            return
+        raise
+
+    if data := value.get("Parameter"):
+        value = parse_conf_data(data["Value"], tomlfy=True)
+
+    return value
+
+
+def _fetch_all_parameters(
+    client,
+    project_prefix: str,
+    env_name: str,
+    namespace_prefix: str | None,
+    silent: bool = True,
+):
+    """
+    Fetch all keys by path segment.
+    """
+
+    path = f"/{project_prefix}/{env_name}"
+    if namespace_prefix is not None:
+        path = f"{path}/{namespace_prefix}"
+
+    logger.debug("Attempting to load all parameters from AWS SSM for path %s" % path)
+
+    data = []
+    paginator = client.get_paginator("get_parameters_by_path")
+
+    try:
+        for page in paginator.paginate(Path=path, Recursive=True, WithDecryption=True):
+            for parameter in page["Parameters"]:
+                data.append({parameter["Name"]: parameter["Value"]})
+
+    except (ClientError, BotoCoreError):
+        logger.exception("Could not connect to AWS SSM.")
+        if silent:
+            return
+        raise
+
+    result = parse_conf_data(data=slashes_to_dict(data), tomlfy=True)
+
+    if result and project_prefix in result:
+        # Prune out the prefixes before setting on the object
+        result = result[project_prefix]
+
+        if result and env_name in result:
+            result = result[env_name]
+
+        if namespace_prefix is not None and namespace_prefix in result:
+            result = result[namespace_prefix]
+
+    return result

--- a/dynaconf_aws_loader/loader.py
+++ b/dynaconf_aws_loader/loader.py
@@ -20,7 +20,7 @@ if t.TYPE_CHECKING:
     from mypy_boto3_ssm.client import SSMClient
 
 
-logger = logging.getLogger("dynaconf")
+logger = logging.getLogger("dynaconf.aws_loader")
 
 
 def get_client(obj) -> SSMClient:
@@ -185,8 +185,8 @@ def _fetch_single_parameter(
 
     try:
         value = client.get_parameter(Name=path, WithDecryption=True)
-    except (ClientError, BotoCoreError):
-        logger.exception("Could not connect to AWS SSM.")
+    except (ClientError, BotoCoreError) as exc:
+        logger.warn("Could not connect to AWS SSM.", exc_info=exc)
         if silent:
             return
         raise
@@ -222,8 +222,8 @@ def _fetch_all_parameters(
             for parameter in page["Parameters"]:
                 data.append({parameter["Name"]: parameter["Value"]})
 
-    except (ClientError, BotoCoreError):
-        logger.exception("Could not connect to AWS SSM.")
+    except (ClientError, BotoCoreError) as exc:
+        logger.warn("Could not connect to AWS SSM.", exc_info=exc)
         if silent:
             return
         raise

--- a/dynaconf_aws_loader/util.py
+++ b/dynaconf_aws_loader/util.py
@@ -54,7 +54,7 @@ class NamespaceFilter:
         """
 
         if not isinstance(prefix, str):
-            raise TypeError("`AWS_SSM_PARAMETER_NAMESPACE_FILTER` must be a string.")
+            raise TypeError("NamespaceFilter prefix must be a string.")
 
         self.prefix = prefix
 

--- a/dynaconf_aws_loader/util.py
+++ b/dynaconf_aws_loader/util.py
@@ -27,3 +27,17 @@ def slashes_to_dict(data: t.Iterable[t.Mapping]) -> t.Mapping:
                     cur_dict = cur_dict.setdefault(field, {})
 
     return result
+
+
+def pull_from_env_or_obj(key_name: str, env: t.Mapping, obj: t.Any) -> t.Optional[str]:
+    """
+    Get value from environment or object, and conditionally set on object.
+    """
+    value: str | None = env.get(key_name)
+
+    if value is None:
+        value = obj.get(key_name)
+    else:
+        obj.set(key_name, value)
+
+    return value

--- a/dynaconf_aws_loader/util.py
+++ b/dynaconf_aws_loader/util.py
@@ -41,3 +41,30 @@ def pull_from_env_or_obj(key_name: str, env: t.Mapping, obj: t.Any) -> t.Optiona
         obj.set(key_name, value)
 
     return value
+
+
+class NamespaceFilter:
+    """
+    Filter hierarchical paths with the same namespace prefix pattern.
+    """
+
+    def __init__(self, prefix: str):
+        """
+        Initialize this filter object with the given ``prefix``.
+        """
+
+        if not isinstance(prefix, str):
+            raise TypeError("`AWS_SSM_PARAMETER_NAMESPACE_FILTER` must be a string.")
+
+        self.prefix = prefix
+
+    def __call__(self, data):
+        """Filter out data that contains the namespace prefix."""
+
+        result = {}
+        for key, value in data.items():
+            if self.prefix in key:
+                continue
+            result[key] = value
+
+        return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,14 @@ Basic test fixtures
 
 """
 
+import typing as t
+import os
 import json
 from pathlib import Path
 import pytest
 
 import boto3
+from dynaconf import Dynaconf
 from localstack_client.patch import enable_local_endpoints
 from mypy_boto3_ssm.client import SSMClient
 
@@ -37,163 +40,275 @@ def ssm_client(docker_localstack):
 
 
 @pytest.fixture
-def default_settings(tmp_path) -> Path:
-    """A fixtured temporary file with a [default] settings section, only."""
+def blank_settings():
+    return Dynaconf()
 
-    data = """
+
+@pytest.fixture
+def basic_settings(
+    tmp_path: Path, ssm_client: SSMClient
+) -> t.Generator[Path, None, None]:
+    """
+    Basic settings with environment layers
+    """
+
+    project_name = "basic"
+
+    data = f"""
     [default]
-    AWS_SSM_PARAMETER_PROJECT_PREFIX = 'testapp'
+    AWS_SSM_PARAMETER_PROJECT_PREFIX = '{project_name}'
     PRODUCT_NAME = "foobar"
     """
-
-    settings_file = tmp_path / "settings.toml"
-    settings_file.write_text(data)
-    return settings_file
-
-
-@pytest.fixture
-def default_settings_with_namespace(tmp_path) -> Path:
-    """
-    A fixtured temporary file with a [default] settings section, and an explict
-    namespace.
-    """
-
-    data = """
-    [default]
-    AWS_SSM_PARAMETER_PROJECT_PREFIX = 'bigapp'
-    AWS_SSM_PARAMETER_NAMESPACE = 'consumer'
-    PRODUCT_NAME = "foobar"
-    """
-
-    settings_file = tmp_path / "settings.toml"
-    settings_file.write_text(data)
-    return settings_file
-
-
-@pytest.fixture
-def settings_without_sections(tmp_path) -> Path:
-    """A fixtured temporary file with no environment/default sections."""
-
-    data = """
-    AWS_SSM_PARAMETER_PROJECT_PREFIX = 'testapp'
-    PRODUCT_NAME = "foobar"
-    """
-
-    settings_file = tmp_path / "settings.toml"
-    settings_file.write_text(data)
-    return settings_file
-
-
-@pytest.fixture
-def basic_environment_parameters(ssm_client: SSMClient):
-    """Setup AWS SSM with some basic path-based parameter data, and remove once completed."""
 
     ssm_client.put_parameter(
-        Name="/testapp/default/products",
+        Name=f"/{project_name}/default/products",
         # Use @json cast for Dynaconf
         # https://www.dynaconf.com/configuration/#auto_cast
         Value="@json %s" % json.dumps({"plans": ["monthly", "yearly"]}),
         Type="String",
     )
     ssm_client.put_parameter(
-        Name="/testapp/development/my_config_value", Value="test123", Type="String"
-    )
-    ssm_client.put_parameter(
-        Name="/testapp/production/database/password",
-        Value="password",
-        Type="SecureString",
-    )
-    ssm_client.put_parameter(
-        Name="/testapp/production/database/host",
-        Value="db.example.com",
-        Type="String",
-    )
-
-    yield
-
-    ssm_client.delete_parameters(
-        Names=[
-            "/testapp/production/database/host",
-            "/testapp/production/database/password",
-            "/testapp/development/my_config_value",
-            "/testapp/default/products",
-        ]
-    )
-
-
-@pytest.fixture
-def environment_less_parameters(ssm_client: SSMClient):
-    """Path-based parameters, but without environment layering."""
-
-    ssm_client.put_parameter(
-        Name="/testapp/default/products",
-        # Use @json cast for Dynaconf
-        # https://www.dynaconf.com/configuration/#auto_cast
-        Value="@json %s" % json.dumps({"plans": ["monthly", "yearly"]}),
-        Type="String",
-    )
-    ssm_client.put_parameter(
-        Name="/testapp/default/my_config_value", Value="test123", Type="String"
-    )
-    ssm_client.put_parameter(
-        Name="/testapp/default/database/password",
-        Value="password",
-        Type="SecureString",
-    )
-    ssm_client.put_parameter(
-        Name="/testapp/default/database/host",
-        Value="db.example.com",
-        Type="String",
-    )
-
-    yield
-
-    ssm_client.delete_parameters(
-        Names=[
-            "/testapp/default/database/host",
-            "/testapp/default/database/password",
-            "/testapp/default/my_config_value",
-            "/testapp/default/products",
-        ]
-    )
-
-
-@pytest.fixture
-def environment_with_namespaced_parameters(ssm_client: SSMClient):
-    """Setup AWS SSM with environment and namespace based parameters."""
-
-    namespace = "consumer"
-
-    ssm_client.put_parameter(
-        Name=f"/bigapp/development/{namespace}/products",
-        # Use @json cast for Dynaconf
-        # https://www.dynaconf.com/configuration/#auto_cast
-        Value="@json %s" % json.dumps({"plans": ["monthly", "yearly"]}),
-        Type="String",
-    )
-    ssm_client.put_parameter(
-        Name=f"/bigapp/development/{namespace}/my_config_value",
+        Name=f"/{project_name}/development/my_config_value",
         Value="test123",
         Type="String",
     )
     ssm_client.put_parameter(
-        Name=f"/bigapp/production/{namespace}/database/password",
+        Name=f"/{project_name}/production/database/password",
         Value="password",
         Type="SecureString",
     )
     ssm_client.put_parameter(
-        Name=f"/bigapp/production/{namespace}/database/host",
+        Name=f"/{project_name}/production/database/host",
         Value="db.example.com",
         Type="String",
     )
 
-    yield
+    settings_file = tmp_path / "settings.toml"
+    settings_file.write_text(data)
+
+    yield settings_file
 
     ssm_client.delete_parameters(
         Names=[
-            f"/bigapp/production/{namespace}/database/host",
-            f"/bigapp/production/{namespace}/database/password",
-            f"/bigapp/development/{namespace}/my_config_value",
-            f"/bigapp/development/{namespace}/products",
+            f"/{project_name}/production/database/host",
+            f"/{project_name}/production/database/password",
+            f"/{project_name}/development/my_config_value",
+            f"/{project_name}/default/products",
         ]
     )
+
+
+@pytest.fixture
+def settings_without_environments(
+    tmp_path: Path, ssm_client: SSMClient
+) -> t.Generator[Path, None, None]:
+    """
+    Basic settings without environment layering
+    """
+
+    project_name = "basic-envless"
+    data = f"""
+    AWS_SSM_PARAMETER_PROJECT_PREFIX = '{project_name}'
+    PRODUCT_NAME = "foobar"
+    """
+
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/default/products",
+        # Use @json cast for Dynaconf
+        # https://www.dynaconf.com/configuration/#auto_cast
+        Value="@json %s" % json.dumps({"plans": ["monthly", "yearly"]}),
+        Type="String",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/default/my_config_value", Value="test123", Type="String"
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/default/database/password",
+        Value="password",
+        Type="SecureString",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/default/database/host",
+        Value="db.example.com",
+        Type="String",
+    )
+
+    settings_file = tmp_path / "settings.toml"
+    settings_file.write_text(data)
+    yield settings_file
+
+    ssm_client.delete_parameters(
+        Names=[
+            f"/{project_name}/default/database/host",
+            f"/{project_name}/default/database/password",
+            f"/{project_name}/default/my_config_value",
+            f"/{project_name}/default/products",
+        ]
+    )
+
+
+@pytest.fixture
+def settings_with_namespace(
+    tmp_path: Path, ssm_client: SSMClient
+) -> t.Generator[Path, None, None]:
+    """
+    Settings with environment layering _and_ namespaces
+    """
+
+    project_name = "basic-namespaced"
+    namespace = "consumer"
+    os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"] = project_name
+    os.environ["AWS_SSM_PARAMETER_NAMESPACE"] = namespace
+
+    data = """
+    [default]
+    PRODUCT_NAME = "foobar"
+    """
+
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/development/{namespace}/products",
+        # Use @json cast for Dynaconf
+        # https://www.dynaconf.com/configuration/#auto_cast
+        Value="@json %s" % json.dumps({"plans": ["monthly", "yearly"]}),
+        Type="String",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/development/{namespace}/my_config_value",
+        Value="test123",
+        Type="String",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/production/{namespace}/database/password",
+        Value="password",
+        Type="SecureString",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/production/{namespace}/database/host",
+        Value="db.example.com",
+        Type="String",
+    )
+
+    settings_file = tmp_path / "settings.toml"
+    settings_file.write_text(data)
+    yield settings_file
+
+    ssm_client.delete_parameters(
+        Names=[
+            f"/{project_name}/production/{namespace}/database/host",
+            f"/{project_name}/production/{namespace}/database/password",
+            f"/{project_name}/development/{namespace}/my_config_value",
+            f"/{project_name}/development/{namespace}/products",
+        ]
+    )
+    del os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"]
+    del os.environ["AWS_SSM_PARAMETER_NAMESPACE"]
+
+
+@pytest.fixture
+def settings_with_namespace_and_non_namespaced(
+    tmp_path: Path, ssm_client: SSMClient
+) -> t.Generator[Path, None, None]:
+    """
+    Layered environment settings with namespaces _and_ without namespaces
+    """
+
+    project_name = "combo"
+    namespace = "pr-123"
+    os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"] = project_name
+    os.environ["AWS_SSM_PARAMETER_NAMESPACE"] = namespace
+
+    data = f"""
+    PRODUCT_NAME = "foobar"
+    """
+
+    # Set up our regular layered environment parameters
+    # #################################################
+
+    # default, for all environments
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/default/products",
+        # Use @json cast for Dynaconf
+        # https://www.dynaconf.com/configuration/#auto_cast
+        Value="@json %s" % json.dumps({"plans": ["monthly", "yearly"]}),
+        Type="String",
+    )
+
+    # QA environment
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/qa/my_config_value", Value="test123", Type="String"
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/qa/database/password",
+        Value="qa-password",
+        Type="SecureString",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/qa/database/host",
+        Value="qa.example.com",
+        Type="String",
+    )
+
+    # Production environment
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/production/database/password",
+        Value="production-password",
+        Type="SecureString",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/production/database/host",
+        Value="production.example.com",
+        Type="String",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/production/region",
+        Value="region-identifier",
+        Type="String",
+    )
+
+    # Now for our namespaced parameters
+    # #################################
+
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/development/{namespace}/products",
+        # Use @json cast for Dynaconf
+        # https://www.dynaconf.com/configuration/#auto_cast
+        Value="@json %s" % json.dumps({"plans": ["namespaced-1", "namespaced-2"]}),
+        Type="String",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/qa/{namespace}/my_config_value",
+        Value="namespaced-qa-value",
+        Type="String",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/production/{namespace}/database/password",
+        Value="namespaced-production-password",
+        Type="SecureString",
+    )
+    ssm_client.put_parameter(
+        Name=f"/{project_name}/production/{namespace}/database/host",
+        Value="namespaced.production.example.com",
+        Type="String",
+    )
+
+    settings_file = tmp_path / "settings.toml"
+    settings_file.write_text(data)
+    yield settings_file
+
+    ssm_client.delete_parameters(
+        Names=[
+            f"/{project_name}/default/products",
+            f"/{project_name}/qa/my_config_value",
+            f"/{project_name}/qa/database/password",
+            f"/{project_name}/qa/database/host",
+            f"/{project_name}/production/database/password",
+            f"/{project_name}/production/database/host",
+            f"/{project_name}/development/{namespace}/products",
+            f"/{project_name}/qa/{namespace}/my_config_value",
+            f"/{project_name}/production/{namespace}/database/password",
+            f"/{project_name}/production/{namespace}/database/host",
+        ]
+    )
+
+    del os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"]
+    del os.environ["AWS_SSM_PARAMETER_NAMESPACE"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def basic_settings(
 
     data = f"""
     [default]
-    AWS_SSM_PARAMETER_PROJECT_PREFIX = '{project_name}'
+    SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF = '{project_name}'
     PRODUCT_NAME = "foobar"
     """
 
@@ -108,7 +108,7 @@ def settings_without_environments(
 
     project_name = "basic-envless"
     data = f"""
-    AWS_SSM_PARAMETER_PROJECT_PREFIX = '{project_name}'
+    SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF = '{project_name}'
     PRODUCT_NAME = "foobar"
     """
 
@@ -157,8 +157,8 @@ def settings_with_namespace(
 
     project_name = "basic-namespaced"
     namespace = "consumer"
-    os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"] = project_name
-    os.environ["AWS_SSM_PARAMETER_NAMESPACE"] = namespace
+    os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"] = project_name
+    os.environ["SSM_PARAMETER_NAMESPACE_FOR_DYNACONF"] = namespace
 
     data = """
     [default]
@@ -200,8 +200,8 @@ def settings_with_namespace(
             f"/{project_name}/development/{namespace}/products",
         ]
     )
-    del os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"]
-    del os.environ["AWS_SSM_PARAMETER_NAMESPACE"]
+    del os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"]
+    del os.environ["SSM_PARAMETER_NAMESPACE_FOR_DYNACONF"]
 
 
 @pytest.fixture
@@ -214,8 +214,8 @@ def settings_with_namespace_and_non_namespaced(
 
     project_name = "combo"
     namespace = "pr-123"
-    os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"] = project_name
-    os.environ["AWS_SSM_PARAMETER_NAMESPACE"] = namespace
+    os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"] = project_name
+    os.environ["SSM_PARAMETER_NAMESPACE_FOR_DYNACONF"] = namespace
 
     data = f"""
     PRODUCT_NAME = "foobar"
@@ -311,5 +311,5 @@ def settings_with_namespace_and_non_namespaced(
         ]
     )
 
-    del os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"]
-    del os.environ["AWS_SSM_PARAMETER_NAMESPACE"]
+    del os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"]
+    del os.environ["SSM_PARAMETER_NAMESPACE_FOR_DYNACONF"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,6 +303,7 @@ def settings_with_namespace_and_non_namespaced(
             f"/{project_name}/qa/database/host",
             f"/{project_name}/production/database/password",
             f"/{project_name}/production/database/host",
+            f"/{project_name}/production/region",
             f"/{project_name}/development/{namespace}/products",
             f"/{project_name}/qa/{namespace}/my_config_value",
             f"/{project_name}/production/{namespace}/database/password",

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -31,7 +31,7 @@ def test_basic_environment_based_settings(
     )
 
     assert dev_settings.current_env == "development"
-    assert dev_settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == "basic"
+    assert dev_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic"
 
     assert dev_settings.MY_CONFIG_VALUE == "test123"
 
@@ -55,7 +55,7 @@ def test_basic_environment_based_settings(
     )
 
     assert prod_settings.current_env == "production"
-    assert prod_settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == "basic"
+    assert prod_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic"
 
     # Loaded from default env
     assert prod_settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
@@ -107,7 +107,7 @@ def test_settings_get_project_prefix_from_environ(
     settings.toml|yaml|etc file present.
     """
 
-    os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"] = "basic-envless"
+    os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"] = "basic-envless"
 
     # Example var for built-in dynaconf env loader to pick up
     os.environ["DYNACONF_PRODUCT_NAME"] = "foobar"
@@ -122,13 +122,13 @@ def test_settings_get_project_prefix_from_environ(
 
     # From the ENV vars that we load
     assert settings.PRODUCT_NAME == "foobar"
-    assert settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == "basic-envless"
+    assert settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic-envless"
 
     # From Parameter store
     assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
     assert settings["DATABASE"] == {"host": "db.example.com", "password": "password"}
 
-    del os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"]
+    del os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"]
     del os.environ["DYNACONF_PRODUCT_NAME"]
 
 
@@ -151,8 +151,8 @@ def test_with_namespace(settings_with_namespace: pathlib.Path):
     )
 
     assert dev_settings.current_env == "development"
-    assert dev_settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == project_name
-    assert dev_settings.AWS_SSM_PARAMETER_NAMESPACE == namespace
+    assert dev_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == project_name
+    assert dev_settings.SSM_PARAMETER_NAMESPACE_FOR_DYNACONF == namespace
 
     # From settings.toml [default] config
     assert dev_settings.PRODUCT_NAME == "foobar"
@@ -196,8 +196,8 @@ def test_with_namespace_merging(
     )
 
     assert settings.current_env == "production"
-    assert settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == project_name
-    assert settings.AWS_SSM_PARAMETER_NAMESPACE == namespace
+    assert settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == project_name
+    assert settings.SSM_PARAMETER_NAMESPACE_FOR_DYNACONF == namespace
 
     # Non-namespaced parameter/values:
     # /combo/production/database/password => production-password
@@ -248,12 +248,12 @@ def test_with_namespace_merging_and_filter(
         LOADERS_FOR_DYNACONF=[
             "dynaconf_aws_loader.loader",
         ],
-        namespace_filter_strategy=NamespaceFilter(namespace_filter_pattern),
+        aws_ssm_namespace_filter_strategy=NamespaceFilter(namespace_filter_pattern),
     )
 
     assert settings.current_env == "production"
-    assert settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == project_name
-    assert settings.AWS_SSM_PARAMETER_NAMESPACE == namespace
+    assert settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == project_name
+    assert settings.SSM_PARAMETER_NAMESPACE_FOR_DYNACONF == namespace
 
     assert settings["DATABASE"] == {
         "host": "namespaced.production.example.com",

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -11,8 +11,7 @@ from dynaconf import Dynaconf
 
 
 def test_basic_environment_based_settings(
-    basic_environment_parameters,
-    default_settings: pathlib.Path,
+    basic_settings: pathlib.Path,
 ):
     """
     Test simple loading of configuration from AWS SSM on a per-environment
@@ -23,14 +22,14 @@ def test_basic_environment_based_settings(
     dev_settings = Dynaconf(
         environments=True,
         FORCE_ENV_FOR_DYNACONF="development",
-        settings_file=str(default_settings.resolve()),
+        settings_file=str(basic_settings.resolve()),
         LOADERS_FOR_DYNACONF=[
             "dynaconf_aws_loader.loader",
         ],
     )
 
     assert dev_settings.current_env == "development"
-    assert dev_settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == "testapp"
+    assert dev_settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == "basic"
 
     assert dev_settings.MY_CONFIG_VALUE == "test123"
 
@@ -47,14 +46,14 @@ def test_basic_environment_based_settings(
     prod_settings = Dynaconf(
         environments=True,
         FORCE_ENV_FOR_DYNACONF="production",
-        settings_file=str(default_settings.resolve()),
+        settings_file=str(basic_settings.resolve()),
         LOADERS_FOR_DYNACONF=[
             "dynaconf_aws_loader.loader",
         ],
     )
 
     assert prod_settings.current_env == "production"
-    assert prod_settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == "testapp"
+    assert prod_settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == "basic"
 
     # Loaded from default env
     assert prod_settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
@@ -75,8 +74,7 @@ def test_basic_environment_based_settings(
 
 
 def test_settings_with_no_environments(
-    environment_less_parameters,
-    settings_without_sections: pathlib.Path,
+    settings_without_environments: pathlib.Path,
 ):
     """
     Test simple loading of configuration from AWS SSM with no environment-based layers.
@@ -84,7 +82,7 @@ def test_settings_with_no_environments(
 
     settings = Dynaconf(
         environments=False,
-        settings_file=str(settings_without_sections.resolve()),
+        settings_file=str(settings_without_environments.resolve()),
         LOADERS_FOR_DYNACONF=[
             "dynaconf_aws_loader.loader",
         ],
@@ -99,7 +97,7 @@ def test_settings_with_no_environments(
 
 
 def test_settings_get_project_prefix_from_environ(
-    environment_less_parameters,
+    settings_without_environments: pathlib.Path,
 ):
     """
     Load the AWS SSM project prefix identifier from os.environ, to avoid the
@@ -107,7 +105,7 @@ def test_settings_get_project_prefix_from_environ(
     settings.toml|yaml|etc file present.
     """
 
-    os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"] = "testapp"
+    os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"] = "basic-envless"
 
     # Example var for built-in dynaconf env loader to pick up
     os.environ["DYNACONF_PRODUCT_NAME"] = "foobar"
@@ -122,32 +120,37 @@ def test_settings_get_project_prefix_from_environ(
 
     # From the ENV vars that we load
     assert settings.PRODUCT_NAME == "foobar"
+    assert settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == "basic-envless"
 
     # From Parameter store
     assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
     assert settings["DATABASE"] == {"host": "db.example.com", "password": "password"}
 
     del os.environ["AWS_SSM_PARAMETER_PROJECT_PREFIX"]
+    del os.environ["DYNACONF_PRODUCT_NAME"]
 
 
-def test_with_namespace(
-    environment_with_namespaced_parameters,
-    default_settings_with_namespace: pathlib.Path,
-):
-    """'An optional namespace may be provided to further group/segment hierarchical parameters."""
+def test_with_namespace(settings_with_namespace: pathlib.Path):
+    """
+    An optional namespace may be provided to further group/segment hierarchical
+    parameters.
+    """
+
+    namespace = "consumer"
+    project_name = "basic-namespaced"
 
     dev_settings = Dynaconf(
         environments=True,
         FORCE_ENV_FOR_DYNACONF="development",
-        settings_file=str(default_settings_with_namespace.resolve()),
+        settings_file=str(settings_with_namespace.resolve()),
         LOADERS_FOR_DYNACONF=[
             "dynaconf_aws_loader.loader",
         ],
     )
 
     assert dev_settings.current_env == "development"
-    assert dev_settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == "bigapp"
-    assert dev_settings.AWS_SSM_PARAMETER_NAMESPACE == "consumer"
+    assert dev_settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == project_name
+    assert dev_settings.AWS_SSM_PARAMETER_NAMESPACE == namespace
 
     # From settings.toml [default] config
     assert dev_settings.PRODUCT_NAME == "foobar"
@@ -162,3 +165,57 @@ def test_with_namespace(
 
     with pytest.raises(KeyError):
         dev_settings["DATABASE"]
+
+
+def test_with_namespace_merging(
+    settings_with_namespace_and_non_namespaced: pathlib.Path,
+):
+    """
+    A namespace was provided, and we desire merging those with the
+    non-namespaced path.
+
+    e.g.
+
+    /testapp/qa/* keys will be loaded, and /testapp/qa/pr-123/* keys will be loaded and
+    override those that were present in /testapp/qa/*
+
+    """
+
+    project_name = "combo"
+    namespace = "pr-123"
+
+    settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="production",
+        settings_file=str(settings_with_namespace_and_non_namespaced.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    assert settings.current_env == "production"
+    assert settings.AWS_SSM_PARAMETER_PROJECT_PREFIX == project_name
+    assert settings.AWS_SSM_PARAMETER_NAMESPACE == namespace
+
+    # Non-namespaced parameter/values:
+    # /combo/production/database/password => production-password
+    # /combo/production/database/host => production.example.com
+    # /combo/production/region => region-identifier
+    #
+    # Namespaced ones:
+    # /combo/production/pr-123/database/password => namespaced-production-password
+    # /combo/production/pr-123/database/host => namespaced.production.example.com
+    #
+    # The namespaced values should override the regular non-namespaced ones, and
+    # merge the rest.
+
+    assert settings["DATABASE"] == {
+        "host": "namespaced.production.example.com",
+        "password": "namespaced-production-password",
+    }
+
+    # Applied as default for all envs/namespaces
+    assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
+
+    # applied for non-namespaced production env
+    assert settings.REGION == "region-identifier"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,6 @@
-from dynaconf_aws_loader.util import slashes_to_dict
+import pytest
+
+from dynaconf_aws_loader.util import pull_from_env_or_obj, slashes_to_dict
 
 
 def test_slashes_to_dict():
@@ -32,3 +34,17 @@ def test_slashes_to_dict():
         },
         "other-app": {"development": {"database": {"host": "127.0.0.1"}}},
     }
+
+
+def test_pull_from_env_or_obj(blank_settings):
+    """
+    Get value from env (dict-like object) or passed settings, and
+    conditionally set this value on the settings.
+    """
+
+    env = {"key1": "value1", "key2": "value2"}
+
+    result = pull_from_env_or_obj(key_name="key1", env=env, obj=blank_settings)
+
+    assert result == "value1"
+    assert blank_settings.key1 == "value1"


### PR DESCRIPTION
## Summary

Previously, if namespaced paths were used for Parameter Store hierarchical configuration, the entire non-namespaced configuration would need to be copied over.

This PR changes the behaviour so that namespaced configurations are merged into the equivalent non-namespaced configuration, which will allow for a more intelligent per-parameter override when necessary instead of requiring full parameter hierarchy duplication for every namespace.

For example, if you have the following keys:

``` text
/app/qa/database/host
/app/qa/database/port
/app/qa/database/password
/app/qa/pr-123/database/host
/app/qa/pr-123/database/password
```

The new behaviour will ensure that the end result of the namespaced configuration loading will include ``database.port``, which previously it would have not.

## Additional Details

- Refactor parameter loading logic into more composable units.
- Refactors test suite.
- Enforce prefix/namespace prefix sourcing from raw env.
- Adds an optional `NamespaceFilter` that can be used to ensure the merged result does not contain dangling namespace keys with their associated data (which was already merged down into the non-namespaced results).