### PR TITLE
Skip when no region is set

### DIFF
--- a/dynaconf_aws_loader/loader.py
+++ b/dynaconf_aws_loader/loader.py
@@ -8,7 +8,7 @@ import typing as t
 import os
 import logging
 import boto3
-from botocore.exceptions import ClientError, BotoCoreError
+from botocore.exceptions import ClientError, BotoCoreError, NoRegionError
 
 from dynaconf.utils import build_env_list
 from dynaconf.utils.parse_conf import parse_conf_data
@@ -82,7 +82,13 @@ def load(
 
     """
 
-    client = get_client(obj)
+    try:
+        client = get_client(obj)
+    except NoRegionError as exc:
+        logging.exception(exc)
+        # We have no region, therefore, we cannot load anything. Just return
+        return
+
     env_list = build_env_list(obj, env or obj.current_env)
 
     project_prefix: str = obj.get(


### PR DESCRIPTION
When in development, Dynaconf does not necessarily need to have credentials sourced, but when loading this extension without credentials, Dynaconf will error out and not proceed past the fact that there are no credentials. I believe this should fail gracefully instead, and skip using this loader.

This outputs the exception, and continues on with Dynaconf loading. Thereby allowing you to know what happened without actually blocking anything.

