### PR TITLE
Enforce Conventional Commit message style via workflow

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -1,0 +1,12 @@
+name: Verify Commit Message Structure
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webiny/action-conventional-commits@v1.1.0


### PR DESCRIPTION
## Summary

Adds a new `check-commits.yml` workflow that verifies commits are using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style on all pull requests that have ``main`` as the target.