### PR TITLE
Rework how environment list is built for environment path key prefix generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ The following optional variables should be set in your ``settings.toml`` (or equ
 
 - ``SSM_ENDPOINT_URL_FOR_DYNACONF``: If your AWS SSM uses a different endpoint than the AWS default. This can be useful for local development when you are running something like `LocalStack <https://localstack.cloud/>`_.
 - ``SSM_SESSION_FOR_DYNACONF``: If you require custom `boto3.session.Session <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`_ arguments, you can specify then as a dictionary here. Note that this will override the default ``boto3`` credential configuration.
+- ``SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF``: Boolean, defaults to ``True``. If you want the SSM loader to load keys under the ``default`` environment name. The key name itself can be set via the Dynaconf setting of ``DEFAULT_ENV_FOR_DYNACONF`` if you want it to be something other than ``default``.
 
 
 Parameter Store Details
@@ -63,7 +64,8 @@ An optional ``namespace`` can be specified as a sub-project grouping for paramet
 
 Note that if you choose to use a ``namespace`` identifier, it must not conflict with existing ``environment`` identifiers.
 
-The ``environment`` identifiers of: ``default``, ``main``, ``global``, and ``dynaconf`` indicate that any parameters nested below said identifiers will be inherited by *all* environments; these names are Dynaconf defaults. This can be useful for setting a default value that can then be overridden on a per-environment basis as necessary.
+If ``SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF`` is set to ``True`` (which is the default value), the loader will add whatever the value of ``DEFAULT_ENV_FOR_DYNACONF`` as an ``environment`` key to load from SSM. The typical use case here is to have a default value for all environments that can be overriden on a per-environment basis as necessary.
+
 
 Security Considerations
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -75,6 +75,49 @@ def test_basic_environment_based_settings(
         assert prod_settings.MY_CONFIG_VALUE == "test123"
 
 
+def test_basic_environment_based_settings_without_default_env(
+    basic_settings_disable_default_env: pathlib.Path,
+):
+    """
+    Test simple loading of configuration from AWS SSM on a per-environment
+    basis, omitting the default environment
+
+    """
+
+    dev_settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="development",
+        settings_file=str(basic_settings_disable_default_env.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    assert dev_settings.current_env == "development"
+    assert dev_settings.SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF is False
+
+    # This should not be set, since we are avoiding defaults
+    with pytest.raises(AttributeError):
+        dev_settings.PRODUCTS
+
+    prod_settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="production",
+        settings_file=str(basic_settings_disable_default_env.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    assert prod_settings.current_env == "production"
+    assert prod_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic"
+
+    # Loaded from default env
+    # This should not be set, since we are avoiding defaults
+    with pytest.raises(AttributeError):
+        prod_settings.PRODUCTS
+
+
 def test_settings_with_no_environments(
     settings_without_environments: pathlib.Path,
 ):


### PR DESCRIPTION
## Summary

The `build_env_list()` function has been rewritten to allow the optional inclusion of the default environment name, set by `DEFAULT_ENV_FOR_DYNACONF`. The use of this default environment key can be disabled completely by setting `SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF` to `False`.

Tests have been added to ensure that if `SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF` is `False` that the loader does _not_ load keys whose environment name is the value of `DEFAULT_ENV_FOR_DYNACONF`, which is `default` if left unspecified.

## Misc

The `README.rst` has been updated to reflect the new functionality.