### PR TITLE
Reorganize Action workflow to utilize python cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,19 +20,22 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      id: setup-python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
         installer-parallel: true
+
+    - name: Lock dependencies for testing
+      run: poetry lock
+
+    - name: Set up Python ${{ matrix.python-version }}
+      id: setup-python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'poetry'
 
     - name: Get latest LocalStack Docker image
       run: docker pull localstack/localstack


### PR DESCRIPTION
## Summary

The previous Action definition was erroneously using the `pip` cache, when in fact it should be using the `poetry` cache. Moreover, as per the [official `setup-python@v4` example](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages), Poetry should be installed _before_ the `setup-python@v4` action is run.