### PR TITLE
Fix single-key parameter loading

### DIFF
--- a/dynaconf_aws_loader/loader.py
+++ b/dynaconf_aws_loader/loader.py
@@ -147,6 +147,7 @@ def load(
                 project_prefix=project_prefix,
                 env_name=env_name,
                 namespace_prefix=namespace_prefix,
+                key=key,
                 silent=silent,
             )
             if value:
@@ -196,7 +197,8 @@ def _fetch_single_parameter(
     client,
     project_prefix: str,
     env_name: str,
-    namespace_prefix: str | None,
+    key: str,
+    namespace_prefix: str | None = None,
     silent: bool = True,
 ):
     """
@@ -206,6 +208,8 @@ def _fetch_single_parameter(
     path = f"/{project_prefix}/{env_name}"
     if namespace_prefix is not None:
         path = f"{path}/{namespace_prefix}"
+
+    path = f"{path}/{key}"
 
     logger.debug("Attempting to load a single parameter %s from AWS SSM" % path)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ boto3-stubs = {extras = ["ssm"], version = "^1.26"}
 localstack-client = "^2.1"
 pytest-env = "^0.8.1"
 
+
+[tool.poetry.group.test.dependencies]
+pytest-mock = "^3.11.1"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_dynaconf_integration.py
+++ b/tests/test_dynaconf_integration.py
@@ -1,0 +1,310 @@
+"""
+Very basic tests
+"""
+
+import os
+import pathlib
+
+import pytest
+
+from dynaconf import Dynaconf
+
+from dynaconf_aws_loader.util import NamespaceFilter
+
+
+def test_basic_environment_based_settings(
+    basic_settings: pathlib.Path,
+):
+    """
+    Test simple loading of configuration from AWS SSM on a per-environment
+    basis.
+
+    """
+
+    dev_settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="development",
+        settings_file=str(basic_settings.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    assert dev_settings.current_env == "development"
+    assert dev_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic"
+
+    assert dev_settings.MY_CONFIG_VALUE == "test123"
+
+    # Loaded from default env
+    assert dev_settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
+
+    # Ensure environment separation of data
+    with pytest.raises(AttributeError):
+        dev_settings.DATABASE
+
+    with pytest.raises(KeyError):
+        dev_settings["DATABASE"]
+
+    prod_settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="production",
+        settings_file=str(basic_settings.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    assert prod_settings.current_env == "production"
+    assert prod_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic"
+
+    # Loaded from default env
+    assert prod_settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
+
+    assert prod_settings["DATABASE"]["HOST"] == "db.example.com"
+
+    # Ensure decryption
+    assert prod_settings["DATABASE"]["PASSWORD"] == "password"
+
+    # Can't load [development] environment config values when current
+    # environment is [production]
+    with pytest.raises(AttributeError):
+        assert prod_settings.MY_CONFIG_VALUE == "test123"
+
+    # Cross-load from a different environment explicitly
+    with prod_settings.using_env("development"):
+        assert prod_settings.MY_CONFIG_VALUE == "test123"
+
+
+def test_basic_environment_based_settings_without_default_env(
+    basic_settings_disable_default_env: pathlib.Path,
+):
+    """
+    Test simple loading of configuration from AWS SSM on a per-environment
+    basis, omitting the default environment
+
+    """
+
+    dev_settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="development",
+        settings_file=str(basic_settings_disable_default_env.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    assert dev_settings.current_env == "development"
+    assert dev_settings.SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF is False
+
+    # This should not be set, since we are avoiding defaults
+    with pytest.raises(AttributeError):
+        dev_settings.PRODUCTS
+
+    prod_settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="production",
+        settings_file=str(basic_settings_disable_default_env.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    assert prod_settings.current_env == "production"
+    assert prod_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic"
+
+    # Loaded from default env
+    # This should not be set, since we are avoiding defaults
+    with pytest.raises(AttributeError):
+        prod_settings.PRODUCTS
+
+
+def test_settings_with_no_environments(
+    settings_without_environments: pathlib.Path,
+):
+    """
+    Test simple loading of configuration from AWS SSM with no environment-based layers.
+    """
+
+    settings = Dynaconf(
+        environments=False,
+        settings_file=str(settings_without_environments.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    # From the ``settings.toml`` that is specified via ``settings_without_sections`` fixture
+    assert settings.PRODUCT_NAME == "foobar"
+
+    # From Parameter store
+    assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
+    assert settings["DATABASE"] == {"host": "db.example.com", "password": "password"}
+
+
+def test_settings_get_project_prefix_from_environ(
+    settings_without_environments: pathlib.Path,
+):
+    """
+    Load the AWS SSM project prefix identifier from os.environ, to avoid the
+    chicken/egg problem if you want to only use env vars instead of having a
+    settings.toml|yaml|etc file present.
+    """
+
+    os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"] = "basic-envless"
+
+    # Example var for built-in dynaconf env loader to pick up
+    os.environ["DYNACONF_PRODUCT_NAME"] = "foobar"
+
+    settings = Dynaconf(
+        environments=False,
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+            "dynaconf.loaders.env_loader",
+        ],
+    )
+
+    # From the ENV vars that we load
+    assert settings.PRODUCT_NAME == "foobar"
+    assert settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic-envless"
+
+    # From Parameter store
+    assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
+    assert settings["DATABASE"] == {"host": "db.example.com", "password": "password"}
+
+    del os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"]
+    del os.environ["DYNACONF_PRODUCT_NAME"]
+
+
+def test_with_namespace(settings_with_namespace: pathlib.Path):
+    """
+    An optional namespace may be provided to further group/segment hierarchical
+    parameters.
+    """
+
+    namespace = "consumer"
+    project_name = "basic-namespaced"
+
+    dev_settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="development",
+        settings_file=str(settings_with_namespace.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    assert dev_settings.current_env == "development"
+    assert dev_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == project_name
+    assert dev_settings.SSM_PARAMETER_NAMESPACE_FOR_DYNACONF == namespace
+
+    # From settings.toml [default] config
+    assert dev_settings.PRODUCT_NAME == "foobar"
+
+    # Ensure our config values are present, and access is transparent to the provided namespace
+    assert dev_settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
+    assert dev_settings.MY_CONFIG_VALUE == "test123"
+
+    # Ensure environment separation of data
+    with pytest.raises(AttributeError):
+        dev_settings.DATABASE
+
+    with pytest.raises(KeyError):
+        dev_settings["DATABASE"]
+
+
+def test_with_namespace_merging(
+    settings_with_namespace_and_non_namespaced: pathlib.Path,
+):
+    """
+    A namespace was provided, and we desire merging those with the
+    non-namespaced path.
+
+    e.g.
+
+    /testapp/qa/* keys will be loaded, and /testapp/qa/pr-123/* keys will be loaded and
+    override those that were present in /testapp/qa/*
+
+    """
+
+    project_name = "combo"
+    namespace = "pr-123"
+
+    settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="production",
+        settings_file=str(settings_with_namespace_and_non_namespaced.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+    )
+
+    assert settings.current_env == "production"
+    assert settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == project_name
+    assert settings.SSM_PARAMETER_NAMESPACE_FOR_DYNACONF == namespace
+
+    # Non-namespaced parameter/values:
+    # /combo/production/database/password => production-password
+    # /combo/production/database/host => production.example.com
+    # /combo/production/region => region-identifier
+    #
+    # Namespaced ones:
+    # /combo/production/pr-123/database/password => namespaced-production-password
+    # /combo/production/pr-123/database/host => namespaced.production.example.com
+    #
+    # The namespaced values should override the regular non-namespaced ones, and
+    # merge the rest.
+
+    assert settings["DATABASE"] == {
+        "host": "namespaced.production.example.com",
+        "password": "namespaced-production-password",
+    }
+
+    # Applied as default for all envs/namespaces
+    assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
+
+    # applied for non-namespaced production env
+    assert settings.REGION == "region-identifier"
+
+    # The namespaced data will still be available directly on the configuration
+    # object. To strip this from the final settings object, we'll need a filter.
+    assert settings.get("pr-123") is not None
+
+
+def test_with_namespace_merging_and_filter(
+    settings_with_namespace_and_non_namespaced: pathlib.Path,
+):
+    """
+    A namespace was provided, and we desire merging those with the
+    non-namespaced path, but we want to filter out the namespaced block
+    in the final settings.
+
+    """
+
+    project_name = "combo"
+    namespace = "pr-123"
+    namespace_filter_pattern = "pr-"
+
+    settings = Dynaconf(
+        environments=True,
+        FORCE_ENV_FOR_DYNACONF="production",
+        settings_file=str(settings_with_namespace_and_non_namespaced.resolve()),
+        LOADERS_FOR_DYNACONF=[
+            "dynaconf_aws_loader.loader",
+        ],
+        aws_ssm_namespace_filter_strategy=NamespaceFilter(namespace_filter_pattern),
+    )
+
+    assert settings.current_env == "production"
+    assert settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == project_name
+    assert settings.SSM_PARAMETER_NAMESPACE_FOR_DYNACONF == namespace
+
+    assert settings["DATABASE"] == {
+        "host": "namespaced.production.example.com",
+        "password": "namespaced-production-password",
+    }
+
+    # Applied as default for all envs/namespaces
+    assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
+    assert settings.REGION == "region-identifier"
+
+    assert settings.get("pr-123") is None

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,310 +1,329 @@
 """
-Very basic tests
+Tests for the loader, sans Dynaconf wrapper
 """
 
-import os
-import pathlib
-
+from datetime import datetime
+import logging
+from dynaconf.base import Settings
 import pytest
 
-from dynaconf import Dynaconf
+from botocore.stub import Stubber
 
-from dynaconf_aws_loader.util import NamespaceFilter
+from dynaconf_aws_loader.loader import (
+    get_client,
+    build_env_list,
+    _fetch_single_parameter,
+    _fetch_all_parameters,
+    load,
+)
 
 
-def test_basic_environment_based_settings(
-    basic_settings: pathlib.Path,
-):
+@pytest.fixture
+def stubbed_client(mocker):
     """
-    Test simple loading of configuration from AWS SSM on a per-environment
-    basis.
+    Use ``boto3`` stubbed client for testing purposes.
 
+    The stub must be activated before usage.
     """
 
-    dev_settings = Dynaconf(
-        environments=True,
-        FORCE_ENV_FOR_DYNACONF="development",
-        settings_file=str(basic_settings.resolve()),
-        LOADERS_FOR_DYNACONF=[
-            "dynaconf_aws_loader.loader",
-        ],
+    settings = mocker.MagicMock()
+    data = {"SSM_ENDPOINT_URL_FOR_DYNACONF": None, "SSM_SESSION_FOR_DYNACONF": {}}
+    settings.get.side_effect = data.get
+    client = get_client(settings)
+
+    return Stubber(client)
+
+
+def test_get_client_default(mocker):
+    """Return a constructed ``boto3`` client for SSM."""
+
+    settings = mocker.MagicMock()
+    data = {"SSM_ENDPOINT_URL_FOR_DYNACONF": None, "SSM_SESSION_FOR_DYNACONF": {}}
+    settings.get.side_effect = data.get
+
+    client = get_client(obj=settings)
+
+    # Defaults
+    assert client.meta.endpoint_url == "http://localhost:4566"
+
+
+def test_get_client_custom_endpoint(mocker):
+    """
+    Get a ``boto3`` client for SSM but with a custom endpoint
+    """
+    settings = mocker.MagicMock()
+    data = {
+        "SSM_ENDPOINT_URL_FOR_DYNACONF": "http://example.com:5555",
+        "SSM_SESSION_FOR_DYNACONF": {},
+    }
+    settings.get.side_effect = data.get
+
+    client = get_client(obj=settings)
+    assert client.meta.endpoint_url == "http://example.com:5555"
+    assert client.meta.region_name == "us-east-1"
+
+
+def test_get_client_custom_boto3_session_parameters(mocker):
+    """
+    Get a ``boto3`` client for SSM but with custom parameters for Session
+    """
+    settings = mocker.MagicMock()
+    data = {
+        "SSM_SESSION_FOR_DYNACONF": {
+            "region_name": "us-west-1",
+        },
+    }
+    settings.get.side_effect = data.get
+
+    client = get_client(obj=settings)
+    assert client.meta.region_name == "us-west-1"
+
+
+def test_build_basic_env_list_without_default(mocker):
+    """Build list of environments for loader to use as path segments"""
+
+    settings = mocker.MagicMock()
+    data = {
+        "SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF": False,
+    }
+    settings.get.side_effect = data.get
+    result = build_env_list(settings, env="testing")
+
+    assert list(result) == ["testing"]
+
+
+@pytest.mark.parametrize("env_name", ["default", "staging"])
+def test_build_basic_env_list_from_settings_with_default(mocker, env_name):
+    """Build list of environments for loader based on environments with default"""
+
+    settings = mocker.MagicMock()
+    data = {
+        "SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF": True,
+        "DEFAULT_ENV_FOR_DYNACONF": env_name,
+    }
+    settings.get.side_effect = data.get
+
+    result = build_env_list(settings, env="testing")
+    assert list(result) == [env_name, "testing"]
+
+
+def test_build_basic_env_list_from_settings_do_not_load_default(mocker):
+    """Build environment list, but ignore default even if set."""
+
+    settings = mocker.MagicMock()
+    data = {
+        "SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF": False,
+        "DEFAULT_ENV_FOR_DYNACONF": "do-not-load-me",
+    }
+    settings.get.side_effect = data.get
+
+    result = build_env_list(settings, env="testing")
+    assert list(result) == ["testing"]
+
+
+def test_fetch_single_parameter_missing(stubbed_client, caplog):
+    """
+    Fetch a single parameter from SSM, but it doesn't exist.
+
+    Ensure that our logger captures this information.
+    """
+
+    stubbed_client.add_client_error(
+        "get_parameter", service_error_code="ParameterNotFound"
     )
 
-    assert dev_settings.current_env == "development"
-    assert dev_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic"
+    with stubbed_client:
+        with pytest.raises(stubbed_client.client.exceptions.ParameterNotFound):
+            with caplog.at_level(logging.WARN, logger="dynaconf.aws_loader"):
+                _fetch_single_parameter(
+                    stubbed_client.client,
+                    project_prefix="foobar",
+                    env_name="testing",
+                    key="baldur",
+                    silent=False,
+                )
 
-    assert dev_settings.MY_CONFIG_VALUE == "test123"
+    assert caplog.record_tuples == [
+        (
+            "dynaconf.aws_loader",
+            logging.WARN,
+            "Parameter with path /foobar/testing/baldur does not exist in AWS SSM.",
+        )
+    ]
 
-    # Loaded from default env
-    assert dev_settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
 
-    # Ensure environment separation of data
-    with pytest.raises(AttributeError):
-        dev_settings.DATABASE
+def test_fetch_all_parameters_missing(stubbed_client, caplog):
+    """
+    Fetch all parameters nested under a path hierarchy, but said hierarchy
+    does not exist.
 
-    with pytest.raises(KeyError):
-        dev_settings["DATABASE"]
+    Ensure that our logger captures this information.
+    """
 
-    prod_settings = Dynaconf(
-        environments=True,
-        FORCE_ENV_FOR_DYNACONF="production",
-        settings_file=str(basic_settings.resolve()),
-        LOADERS_FOR_DYNACONF=[
-            "dynaconf_aws_loader.loader",
-        ],
+    stubbed_client.add_client_error(
+        "get_parameters_by_path", service_error_code="ParameterNotFound"
     )
 
-    assert prod_settings.current_env == "production"
-    assert prod_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic"
+    with stubbed_client:
+        with pytest.raises(stubbed_client.client.exceptions.ParameterNotFound):
+            with caplog.at_level(logging.WARN, logger="dynaconf.aws_loader"):
+                _fetch_all_parameters(
+                    stubbed_client.client,
+                    project_prefix="foobar",
+                    env_name="testing",
+                    silent=False,
+                )
 
-    # Loaded from default env
-    assert prod_settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
-
-    assert prod_settings["DATABASE"]["HOST"] == "db.example.com"
-
-    # Ensure decryption
-    assert prod_settings["DATABASE"]["PASSWORD"] == "password"
-
-    # Can't load [development] environment config values when current
-    # environment is [production]
-    with pytest.raises(AttributeError):
-        assert prod_settings.MY_CONFIG_VALUE == "test123"
-
-    # Cross-load from a different environment explicitly
-    with prod_settings.using_env("development"):
-        assert prod_settings.MY_CONFIG_VALUE == "test123"
+    assert caplog.record_tuples == [
+        (
+            "dynaconf.aws_loader",
+            logging.WARN,
+            "Parameter with path /foobar/testing does not exist in AWS SSM.",
+        )
+    ]
 
 
-def test_basic_environment_based_settings_without_default_env(
-    basic_settings_disable_default_env: pathlib.Path,
-):
-    """
-    Test simple loading of configuration from AWS SSM on a per-environment
-    basis, omitting the default environment
+def test_fetch_single_parameter(stubbed_client):
+    """Fetch a single parameter from SSM."""
 
-    """
+    stubbed_response = {
+        "Parameter": {
+            "Name": "/foobar/testing/baldur",
+            "Type": "String",
+            "Value": "gate",
+            "Version": 1,
+            "LastModifiedDate": datetime(2015, 1, 1),
+            "ARN": "fake::arn",
+            "DataType": "text",
+        }
+    }
+    expected_params = {"Name": "/foobar/testing/baldur", "WithDecryption": True}
 
-    dev_settings = Dynaconf(
-        environments=True,
-        FORCE_ENV_FOR_DYNACONF="development",
-        settings_file=str(basic_settings_disable_default_env.resolve()),
-        LOADERS_FOR_DYNACONF=[
-            "dynaconf_aws_loader.loader",
+    stubbed_client.add_response("get_parameter", stubbed_response, expected_params)
+
+    with stubbed_client:
+        result = _fetch_single_parameter(
+            stubbed_client.client,
+            project_prefix="foobar",
+            env_name="testing",
+            key="baldur",
+        )
+
+    assert result == "gate"
+
+
+def test_fetch_all_parameters_by_path(stubbed_client):
+    """Fetch all parameters by hierarchical path from SSM."""
+
+    stubbed_response = {
+        "Parameters": [
+            {
+                "Name": "/foobar/testing/database/host",
+                "Type": "String",
+                "Value": "localhost",
+                "Version": 1,
+                "LastModifiedDate": datetime(2015, 1, 1),
+                "ARN": "fake::arn",
+                "DataType": "text",
+            },
+            {
+                "Name": "/foobar/testing/database/port",
+                "Type": "String",
+                "Value": "5432",
+                "Version": 1,
+                "LastModifiedDate": datetime(2015, 1, 1),
+                "ARN": "fake::arn",
+                "DataType": "text",
+            },
+            {
+                "Name": "/foobar/testing/debug",
+                "Type": "String",
+                "Value": "@bool True",
+                "Version": 1,
+                "LastModifiedDate": datetime(2015, 1, 1),
+                "ARN": "fake::arn",
+                "DataType": "text",
+            },
         ],
-    )
-
-    assert dev_settings.current_env == "development"
-    assert dev_settings.SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF is False
-
-    # This should not be set, since we are avoiding defaults
-    with pytest.raises(AttributeError):
-        dev_settings.PRODUCTS
-
-    prod_settings = Dynaconf(
-        environments=True,
-        FORCE_ENV_FOR_DYNACONF="production",
-        settings_file=str(basic_settings_disable_default_env.resolve()),
-        LOADERS_FOR_DYNACONF=[
-            "dynaconf_aws_loader.loader",
-        ],
-    )
-
-    assert prod_settings.current_env == "production"
-    assert prod_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic"
-
-    # Loaded from default env
-    # This should not be set, since we are avoiding defaults
-    with pytest.raises(AttributeError):
-        prod_settings.PRODUCTS
-
-
-def test_settings_with_no_environments(
-    settings_without_environments: pathlib.Path,
-):
-    """
-    Test simple loading of configuration from AWS SSM with no environment-based layers.
-    """
-
-    settings = Dynaconf(
-        environments=False,
-        settings_file=str(settings_without_environments.resolve()),
-        LOADERS_FOR_DYNACONF=[
-            "dynaconf_aws_loader.loader",
-        ],
-    )
-
-    # From the ``settings.toml`` that is specified via ``settings_without_sections`` fixture
-    assert settings.PRODUCT_NAME == "foobar"
-
-    # From Parameter store
-    assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
-    assert settings["DATABASE"] == {"host": "db.example.com", "password": "password"}
-
-
-def test_settings_get_project_prefix_from_environ(
-    settings_without_environments: pathlib.Path,
-):
-    """
-    Load the AWS SSM project prefix identifier from os.environ, to avoid the
-    chicken/egg problem if you want to only use env vars instead of having a
-    settings.toml|yaml|etc file present.
-    """
-
-    os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"] = "basic-envless"
-
-    # Example var for built-in dynaconf env loader to pick up
-    os.environ["DYNACONF_PRODUCT_NAME"] = "foobar"
-
-    settings = Dynaconf(
-        environments=False,
-        LOADERS_FOR_DYNACONF=[
-            "dynaconf_aws_loader.loader",
-            "dynaconf.loaders.env_loader",
-        ],
-    )
-
-    # From the ENV vars that we load
-    assert settings.PRODUCT_NAME == "foobar"
-    assert settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == "basic-envless"
-
-    # From Parameter store
-    assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
-    assert settings["DATABASE"] == {"host": "db.example.com", "password": "password"}
-
-    del os.environ["SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF"]
-    del os.environ["DYNACONF_PRODUCT_NAME"]
-
-
-def test_with_namespace(settings_with_namespace: pathlib.Path):
-    """
-    An optional namespace may be provided to further group/segment hierarchical
-    parameters.
-    """
-
-    namespace = "consumer"
-    project_name = "basic-namespaced"
-
-    dev_settings = Dynaconf(
-        environments=True,
-        FORCE_ENV_FOR_DYNACONF="development",
-        settings_file=str(settings_with_namespace.resolve()),
-        LOADERS_FOR_DYNACONF=[
-            "dynaconf_aws_loader.loader",
-        ],
-    )
-
-    assert dev_settings.current_env == "development"
-    assert dev_settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == project_name
-    assert dev_settings.SSM_PARAMETER_NAMESPACE_FOR_DYNACONF == namespace
-
-    # From settings.toml [default] config
-    assert dev_settings.PRODUCT_NAME == "foobar"
-
-    # Ensure our config values are present, and access is transparent to the provided namespace
-    assert dev_settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
-    assert dev_settings.MY_CONFIG_VALUE == "test123"
-
-    # Ensure environment separation of data
-    with pytest.raises(AttributeError):
-        dev_settings.DATABASE
-
-    with pytest.raises(KeyError):
-        dev_settings["DATABASE"]
-
-
-def test_with_namespace_merging(
-    settings_with_namespace_and_non_namespaced: pathlib.Path,
-):
-    """
-    A namespace was provided, and we desire merging those with the
-    non-namespaced path.
-
-    e.g.
-
-    /testapp/qa/* keys will be loaded, and /testapp/qa/pr-123/* keys will be loaded and
-    override those that were present in /testapp/qa/*
-
-    """
-
-    project_name = "combo"
-    namespace = "pr-123"
-
-    settings = Dynaconf(
-        environments=True,
-        FORCE_ENV_FOR_DYNACONF="production",
-        settings_file=str(settings_with_namespace_and_non_namespaced.resolve()),
-        LOADERS_FOR_DYNACONF=[
-            "dynaconf_aws_loader.loader",
-        ],
-    )
-
-    assert settings.current_env == "production"
-    assert settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == project_name
-    assert settings.SSM_PARAMETER_NAMESPACE_FOR_DYNACONF == namespace
-
-    # Non-namespaced parameter/values:
-    # /combo/production/database/password => production-password
-    # /combo/production/database/host => production.example.com
-    # /combo/production/region => region-identifier
-    #
-    # Namespaced ones:
-    # /combo/production/pr-123/database/password => namespaced-production-password
-    # /combo/production/pr-123/database/host => namespaced.production.example.com
-    #
-    # The namespaced values should override the regular non-namespaced ones, and
-    # merge the rest.
-
-    assert settings["DATABASE"] == {
-        "host": "namespaced.production.example.com",
-        "password": "namespaced-production-password",
     }
 
-    # Applied as default for all envs/namespaces
-    assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
-
-    # applied for non-namespaced production env
-    assert settings.REGION == "region-identifier"
-
-    # The namespaced data will still be available directly on the configuration
-    # object. To strip this from the final settings object, we'll need a filter.
-    assert settings.get("pr-123") is not None
-
-
-def test_with_namespace_merging_and_filter(
-    settings_with_namespace_and_non_namespaced: pathlib.Path,
-):
-    """
-    A namespace was provided, and we desire merging those with the
-    non-namespaced path, but we want to filter out the namespaced block
-    in the final settings.
-
-    """
-
-    project_name = "combo"
-    namespace = "pr-123"
-    namespace_filter_pattern = "pr-"
-
-    settings = Dynaconf(
-        environments=True,
-        FORCE_ENV_FOR_DYNACONF="production",
-        settings_file=str(settings_with_namespace_and_non_namespaced.resolve()),
-        LOADERS_FOR_DYNACONF=[
-            "dynaconf_aws_loader.loader",
-        ],
-        aws_ssm_namespace_filter_strategy=NamespaceFilter(namespace_filter_pattern),
-    )
-
-    assert settings.current_env == "production"
-    assert settings.SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF == project_name
-    assert settings.SSM_PARAMETER_NAMESPACE_FOR_DYNACONF == namespace
-
-    assert settings["DATABASE"] == {
-        "host": "namespaced.production.example.com",
-        "password": "namespaced-production-password",
+    expected_params = {
+        "Path": "/foobar/testing",
+        "Recursive": True,
+        "WithDecryption": True,
     }
 
-    # Applied as default for all envs/namespaces
-    assert settings.PRODUCTS == {"plans": ["monthly", "yearly"]}
-    assert settings.REGION == "region-identifier"
+    stubbed_client.add_response(
+        "get_parameters_by_path", stubbed_response, expected_params
+    )
 
-    assert settings.get("pr-123") is None
+    with stubbed_client:
+        result = _fetch_all_parameters(
+            stubbed_client.client,
+            project_prefix="foobar",
+            env_name="testing",
+        )
+
+    assert result == {"database": {"host": "localhost", "port": 5432}, "debug": True}
+
+
+def test_load(mocker, stubbed_client):
+    """Straightforward test of main functionality of AWS SSM loader"""
+
+    settings = Settings(
+        SSM_LOAD_DEFAULT_ENV_FOR_DYNACONF=False,
+        SSM_PARAMETER_PROJECT_PREFIX_FOR_DYNACONF="foobar",
+    )
+
+    stubbed_response = {
+        "Parameters": [
+            {
+                "Name": "/foobar/testing/database/host",
+                "Type": "String",
+                "Value": "localhost",
+                "Version": 1,
+                "LastModifiedDate": datetime(2015, 1, 1),
+                "ARN": "fake::arn",
+                "DataType": "text",
+            },
+            {
+                "Name": "/foobar/testing/database/port",
+                "Type": "String",
+                "Value": "5432",
+                "Version": 1,
+                "LastModifiedDate": datetime(2015, 1, 1),
+                "ARN": "fake::arn",
+                "DataType": "text",
+            },
+            {
+                "Name": "/foobar/testing/debug",
+                "Type": "String",
+                "Value": "@bool True",
+                "Version": 1,
+                "LastModifiedDate": datetime(2015, 1, 1),
+                "ARN": "fake::arn",
+                "DataType": "text",
+            },
+        ],
+    }
+
+    expected_params = {
+        "Path": "/foobar/testing",
+        "Recursive": True,
+        "WithDecryption": True,
+    }
+
+    stubbed_client.add_response(
+        "get_parameters_by_path", stubbed_response, expected_params
+    )
+
+    mocker.patch(
+        "dynaconf_aws_loader.loader.get_client", return_value=stubbed_client.client
+    )
+
+    with stubbed_client:
+        load(settings, env="testing")
+
+    assert settings.DATABASE.HOST == "localhost"
+    assert settings.DATABASE.PORT == 5432
+    assert settings.DEBUG == True


### PR DESCRIPTION
The ability to load a single key via the AWS SSM loader was incorrectly implemented. This PR addresses that issue.

Additionally, unit-ish tests have been added for testing the loader, which supplement the pre-existing Dynaconf integration tests.

Finally, the logger messages were tweaked again to help straddle the line of too much information vs. not enough.