### PR TITLE
Replace warn logging with info/error

### DIFF
--- a/dynaconf_aws_loader/loader.py
+++ b/dynaconf_aws_loader/loader.py
@@ -219,17 +219,17 @@ def _fetch_single_parameter(
     try:
         value = client.get_parameter(Name=path, WithDecryption=True)
     except ClientError as exc:
-        if exc.response.get("Error", {}).get("Code") == "ParameterNotFound":
-            logger.warn("Parameter with path %s does not exist in AWS SSM." % path)
         if silent:
             return
+        if exc.response.get("Error", {}).get("Code") == "ParameterNotFound":
+            logger.info("Parameter with path %s does not exist in AWS SSM." % path)
         raise
     except BotoCoreError:
-        logger.warn(
-            "Could not connect to AWS SSM at endpoint %s." % client.meta.endpoint_url
-        )
         if silent:
             return
+        logger.error(
+            "Could not connect to AWS SSM at endpoint %s." % client.meta.endpoint_url
+        )
         raise
 
     if data := value.get("Parameter"):
@@ -264,17 +264,17 @@ def _fetch_all_parameters(
                 data.append({parameter["Name"]: parameter["Value"]})
 
     except ClientError as exc:
-        if exc.response.get("Error", {}).get("Code") == "ParameterNotFound":
-            logger.warn("Parameter with path %s does not exist in AWS SSM." % path)
         if silent:
             return
+        if exc.response.get("Error", {}).get("Code") == "ParameterNotFound":
+            logger.info("Parameter with path %s does not exist in AWS SSM." % path)
         raise
     except BotoCoreError:
-        logger.warn(
-            "Could not connect to AWS SSM at endpoint %s." % client.meta.endpoint_url
-        )
         if silent:
             return
+        logger.error(
+            "Could not connect to AWS SSM at endpoint %s." % client.meta.endpoint_url
+        )
         raise
 
     result = parse_conf_data(data=slashes_to_dict(data), tomlfy=True)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -134,7 +134,7 @@ def test_fetch_single_parameter_missing(stubbed_client, caplog):
 
     with stubbed_client:
         with pytest.raises(stubbed_client.client.exceptions.ParameterNotFound):
-            with caplog.at_level(logging.WARN, logger="dynaconf.aws_loader"):
+            with caplog.at_level(logging.INFO, logger="dynaconf.aws_loader"):
                 _fetch_single_parameter(
                     stubbed_client.client,
                     project_prefix="foobar",
@@ -146,7 +146,7 @@ def test_fetch_single_parameter_missing(stubbed_client, caplog):
     assert caplog.record_tuples == [
         (
             "dynaconf.aws_loader",
-            logging.WARN,
+            logging.INFO,
             "Parameter with path /foobar/testing/baldur does not exist in AWS SSM.",
         )
     ]
@@ -166,7 +166,7 @@ def test_fetch_all_parameters_missing(stubbed_client, caplog):
 
     with stubbed_client:
         with pytest.raises(stubbed_client.client.exceptions.ParameterNotFound):
-            with caplog.at_level(logging.WARN, logger="dynaconf.aws_loader"):
+            with caplog.at_level(logging.INFO, logger="dynaconf.aws_loader"):
                 _fetch_all_parameters(
                     stubbed_client.client,
                     project_prefix="foobar",
@@ -177,7 +177,7 @@ def test_fetch_all_parameters_missing(stubbed_client, caplog):
     assert caplog.record_tuples == [
         (
             "dynaconf.aws_loader",
-            logging.WARN,
+            logging.INFO,
             "Parameter with path /foobar/testing does not exist in AWS SSM.",
         )
     ]


### PR DESCRIPTION
Additionally, respect the `silent` parameter a bit more strictly; if `silent=True`, don't emit log lines.