### PR TITLE
Handle loader identifier changes between Dynaconf 3.1->3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
+        dynaconf-version: ["3.1.12", "3.2.0"]
     steps:
 
     - uses: actions/checkout@v3
@@ -42,6 +43,9 @@ jobs:
 
     - name: Install dependencies
       run: poetry install
+
+    - name: Override with specific Dynaconf version(s)
+      run: poetry add dynaconf==${{ matrix.dynaconf-version }}
 
     - name: Run Tests with PyTest for Python ${{ matrix.python-version }}
       run: poetry run pytest --verbose -rsxX --color=auto

--- a/dynaconf_aws_loader/__init__.py
+++ b/dynaconf_aws_loader/__init__.py
@@ -1,12 +1,33 @@
 """
 Dynaconf Loader for AWS Secrets Manager
 """
+import typing as t
 
 from importlib.metadata import version
 
 # Pull version from the package data; canonical source is pyproject.toml
 __version__ = version(__package__)
 
-# The loader identifier, which is used to identify the provenance of compiled
-# configuration key/value pairs in the resulting ``Settings`` object.
-IDENTIFIER = "aws-ssm"
+
+def generate_loader_identifier(path: str, env: str):
+    """
+    The loader identifier, which is used to identify the provenance of compiled
+    configuration key/value pairs in the resulting ``Settings`` object.
+
+    :param path: String-based path to identify where the value has been sourced from
+    :param env: String-based env name
+    """
+
+    # Dynamic import here, due to the changes between Dynaconf 3.1 and 3.2 with
+    # respect to loader identifiers.
+    try:
+        # Use the new-style source metadata loading for better introspection
+        # of where values are sourced from.
+        from dynaconf.loaders.base import SourceMetadata
+
+        loader_identifier = SourceMetadata(loader="aws-ssm", identifier=path, env=env)
+    except ImportError:  # Dynaconf<=3.1, simply return a string.
+        # Use the old-style string identifiers.
+        loader_identifier = "aws-ssm"
+
+    return loader_identifier

--- a/dynaconf_aws_loader/loader.py
+++ b/dynaconf_aws_loader/loader.py
@@ -12,8 +12,8 @@ from botocore.exceptions import ClientError, BotoCoreError, NoRegionError
 
 from dynaconf.utils.parse_conf import parse_conf_data
 
-from . import IDENTIFIER
 from .util import slashes_to_dict, pull_from_env_or_obj
+from . import generate_loader_identifier
 
 if t.TYPE_CHECKING:
     from mypy_boto3_ssm.client import SSMClient
@@ -141,6 +141,8 @@ def load(
         if namespace_prefix is not None:
             path = f"{path}/{namespace_prefix}"
 
+        loader_identifier = generate_loader_identifier(path, env)
+
         if key is not None:
             value = _fetch_single_parameter(
                 client,
@@ -173,7 +175,7 @@ def load(
 
                 obj.update(
                     normal_results,
-                    loader_identifier=IDENTIFIER,
+                    loader_identifier=loader_identifier,
                     validate=validate,
                 )
 
@@ -189,7 +191,7 @@ def load(
                 if namespaced_results:
                     obj.update(
                         namespaced_results,
-                        loader_identifier=IDENTIFIER,
+                        loader_identifier=loader_identifier,
                         validate=validate,
                     )
 


### PR DESCRIPTION
## Summary

Dynaconf made a breaking change in how loaders are handled in dynaconf/dynaconf#939.

Previous to `3.2`, the loader identifier was a simple string. As of `3.2`, loaders must utilize a `namedtuple` of `SourceMetadata` that contains the following attributes:

    - loader: the loader type (envvar_global, yaml, redis, vault..)
    - identifier: a loader identifier (eg, for file types it is the filename), for other it may be unique.
    - env: the env in which the data was loaded
    - merged: if the data was processed with some merge operation.


Dynaconf itself does not seem to provide a reasonable upgrade path for this breaking change, hence the necessity for the dynamic import of `SourceMetadata` to determine which format to use for the loader identifier.